### PR TITLE
Set type:module in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "svelte-textfit",
   "version": "1.1.3",
+  "type": "module",
   "description": "Svelte action to fit headlines and paragraphs into any element. Ported from react-textfit",
   "main": "src/index.js",
   "types": "src/index.d.ts",


### PR DESCRIPTION
index.js is an ES6 module, and so requires type: module be set in package.json to work properly in all setups.


It would also suffice to rename it to index.mjs, and not touch package.json, i believe.